### PR TITLE
Get complete data from prismic pagination

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -81,6 +81,7 @@ function plugin(config) {
                 // create associative array of query keys and their query & formName
                 for (var queryKey in file.prismic) {
                     debug("processing %s", queryKey);
+                    file.prismic[queryKey].results = [];
                     var queryString = file.prismic[queryKey].query;
                     var orderings = file.prismic[queryKey].orderings;
                     var pageSize = file.prismic[queryKey].pageSize;
@@ -98,23 +99,51 @@ function plugin(config) {
                             collectionQuery = queryKey;
                         }
                     }
-                    queryKeys[queryKey] = {"queryString": queryString, "pageSize": pageSize, "orderings": orderings, "formName": formName};
+                    queryKeys[queryKey] = {"queryString": queryString,
+                                           "pageSize": pageSize,
+                                           "orderings": orderings,
+                                           "formName": formName};
                 }
 
                 // asynchronously retrieve and process each query
                 each(Object.keys(queryKeys), function (currentQueryKey, queriedAndProcessedCallback) {
                     debug("%s: api.form(\"%s\").query('%s').ref(ctx.ref).submit()", queryKey, formName, queryString);
-                    ctx.api.form(queryKeys[currentQueryKey].formName).query(queryKeys[currentQueryKey].queryString).pageSize(queryKeys[currentQueryKey].pageSize).orderings(queryKeys[currentQueryKey].orderings).ref(ctx.ref).submit(function(err, d) {
+                    var totalPages;
+                    var page = 1;
+
+                    queryNextPage();
+
+                    function queryNextPage() {
+                        ctx.api.form(queryKeys[currentQueryKey].formName)
+                            .query(queryKeys[currentQueryKey].queryString)
+                            .pageSize(queryKeys[currentQueryKey].pageSize)
+                            .page(page)
+                            .orderings(queryKeys[currentQueryKey].orderings)
+                            .ref(ctx.ref).submit(prismicCallback);
+                    }
+
+                    function prismicCallback(err, d) {
                         if (err) {
                             console.error(err);
                         }
                         else {
-                            processRetrievedContent(d, file.prismic, currentQueryKey, ctx)
+                            processRetrievedContent(d, file.prismic, currentQueryKey, ctx);
+                            totalPages = d.total_pages;
+                            if (page < totalPages) {
+                                page++;
+                                queryNextPage();
+                            } else {
+                                queriedAndProcessedCallback();
+                            }
                         }
+                    }
 
-                        queriedAndProcessedCallback();
-                    });
-                }, function(err){if(err != null){console.log(err);}generateCollectionFiles(fileName, collectionQuery, callback, ctx)});
+                }, function(err){
+                    if(err != null) {
+                        console.log(err);
+                    }
+                    generateCollectionFiles(fileName, collectionQuery, callback, ctx);
+                });
             } else {
                 callback();
             }
@@ -122,13 +151,12 @@ function plugin(config) {
 
         // processes the retrieved content and adds it to the metadata
         function processRetrievedContent(content, filePrismicMetadata, queryKey, ctx) {
-            var results = [];
             if (content.results != null && content.results.length > 0) {
                 for (var i = 0; i < content.results.length; i++) {
 
                     // add the complete result except for the data fragments
                     var result = _.omit(content.results[i], 'fragments');
-                    result.data = {}
+                    result.data = {};
 
                     // process the data fragments, invoking helpers to make the data more usable
                     if (content.results[i].fragments != null && Object.keys(content.results[i].fragments).length  > 0) {
@@ -141,10 +169,9 @@ function plugin(config) {
                             result.data[fragmentName].html = content.results[i].get(fragmentFullName).asHtml(ctx.linkResolver);
                         }
                     }
-                    results.push(result);
+                    filePrismicMetadata[queryKey].results.push(result);
                 }
             }
-            filePrismicMetadata[queryKey].results = results;
         }
 
         // if any of the queries are designated the collection query, then generate a file for each of the results
@@ -170,7 +197,7 @@ function plugin(config) {
                 }
 
                 delete files[fileName];
-                _.extend(files, newFiles)
+                _.extend(files, newFiles);
             }
 
             callback();

--- a/lib/index.js
+++ b/lib/index.js
@@ -85,6 +85,7 @@ function plugin(config) {
                     var queryString = file.prismic[queryKey].query;
                     var orderings = file.prismic[queryKey].orderings;
                     var pageSize = file.prismic[queryKey].pageSize;
+                    var allPages = file.prismic[queryKey].allPages;
                     var formName = file.prismic[queryKey].formName;
                     if (formName == null) {
                         formName = "everything"
@@ -101,6 +102,7 @@ function plugin(config) {
                     }
                     queryKeys[queryKey] = {"queryString": queryString,
                                            "pageSize": pageSize,
+                                           "allPages": allPages,
                                            "orderings": orderings,
                                            "formName": formName};
                 }
@@ -129,7 +131,8 @@ function plugin(config) {
                         else {
                             processRetrievedContent(d, file.prismic, currentQueryKey, ctx);
                             totalPages = d.total_pages;
-                            if (page < totalPages) {
+                            if (queryKeys[currentQueryKey].allPages &&
+                                page < totalPages) {
                                 page++;
                                 queryNextPage();
                             } else {


### PR DESCRIPTION
With these changes, metalsmith-prismic pulls data from all pages when a resource is paginated.

fixes #19 