### PR TITLE
Use node-clone to perform deep copy in creating collection files

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -4,7 +4,7 @@ var each        = require('async').each
 var Prismic     = require('prismic.io').Prismic
 var debug       = require('debug')('metalsmith-prismic')
 var _           = require('underscore')
-
+var clone       = require('clone')
 /**
  * Expose `plugin`.
  */
@@ -182,14 +182,13 @@ function plugin(config) {
             if (collectionQuery != null) {
                 var file = files[fileName];
                 var newFiles = {};
-                var fileJson = JSON.stringify(file);
                 var fileExtension = file.prismic[collectionQuery].collection.fileExtension;
                 var fileSuffix = (fileExtension != undefined && fileExtension !== "")? "." + fileExtension:"";
                 // for every result in the collection query
                 for (var i = 0; i < file.prismic[collectionQuery].results.length; i++) {
 
                     // clone the file and replace the original collectionQuery results with the current result
-                    var newFile = JSON.parse(fileJson);
+                    var newFile = clone(file);
                     newFile.prismic[collectionQuery].results = [file.prismic[collectionQuery].results[i]];
 
                     // add the filename to the ctx object to make it available for use in the linkResolver function

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "homepage": "https://github.com/mbanting/metalsmith-prismic",
   "dependencies": {
     "async": "^1.2.1",
+    "clone": "^1.0.2",
     "debug": "^2.2.0",
     "prismic.io": "1.1.7",
     "underscore": "^1.8.3"

--- a/test/index.js
+++ b/test/index.js
@@ -1,4 +1,5 @@
 var equal = require('assert-dir-equal');
+var assert = require('assert');
 var Metalsmith = require('metalsmith');
 var prismic = require('..');
 var templates = require('metalsmith-templates');
@@ -147,6 +148,30 @@ describe('metalsmith-prismic', function(){
             .build(function(err){
                 if (err) return done(err);
                 equal('test/fixtures/appPages/expected', 'test/fixtures/appPages/build');
+                done();
+            });
+    });
+
+    it('should preserve file contents as Buffer on collection files', function(done){
+        Metalsmith('test/fixtures/collection')
+            .use(prismic({
+                "url": "http://lesbonneschoses.prismic.io/api"
+            }))
+
+            //.use (log())
+
+            // use custom plugin to detect content types
+            .use(function(files, metalsmith, msDone) {
+                var n = Object.keys(files).filter(function(file) {
+                    console.log('I HAVE A FILE')
+                    return files[file].contents.constructor !== Buffer;
+                });
+                assert.equal(n, 0);
+                msDone();
+            })
+
+            .build(function(err){
+                if (err) return done(err);
                 done();
             });
     });


### PR DESCRIPTION
When metalsmith-prismic creates collection files, it uses JSON.stringify-JSON.parse to deep clone the source file. This doesn't serialize the contents-field which is a buffer Object but leaves it as a string "[object Object]".

This pull request uses node-clone to perform the deep copy, preserving the contents-field as Buffer-object that can be then used correctly in further plugins down the chain. 