### PR TITLE
Add support for passing custom references

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -47,6 +47,11 @@ function plugin(config) {
                     }
                 }
 
+                // user release as reference if no reference found
+                if (!ref) {
+                  ref = release || 'master';
+                }
+
                 // setup the context object
                 ctx.api = api;
                 ctx.linkResolver = getLinkResolver(ctx);
@@ -127,6 +132,7 @@ function plugin(config) {
                     function prismicCallback(err, d) {
                         if (err) {
                             console.error(err);
+                            callback(err);
                         }
                         else {
                             processRetrievedContent(d, file.prismic, currentQueryKey, ctx);

--- a/lib/index.js
+++ b/lib/index.js
@@ -131,8 +131,7 @@ function plugin(config) {
 
                     function prismicCallback(err, d) {
                         if (err) {
-                            console.error(err);
-                            callback(err);
+                            queriedAndProcessedCallback(err);
                         }
                         else {
                             processRetrievedContent(d, file.prismic, currentQueryKey, ctx);
@@ -150,6 +149,8 @@ function plugin(config) {
                 }, function(err){
                     if(err != null) {
                         console.log(err);
+                        callback(err);
+                        return;
                     }
                     generateCollectionFiles(fileName, collectionQuery, callback, ctx);
                 });

--- a/test/fixtures/preview/expected/index.html
+++ b/test/fixtures/preview/expected/index.html
@@ -1,0 +1,26 @@
+<html>
+<body>
+<ul>
+    <li>
+        <h1>Golden Gate Cupcake</h1>
+        <p>The launch of <a href="/store/UlfoxUnM0wkXYXbq/san-francisco-pier-39">our brand new San Francisco shop</a> would not have been complete without a proper celebration in taste! An occasion to see the berries on its top (as red and sunny as the Golden Gate Bridge) mingle with the soft fruit in its cake (as natural as San Francisco's organic food). Also, an occasion to celebrate high-tech, because it is the occasion to see the encounter of... apples and blackberries! A state of the art pastry, if you will...</p>
+    </li>
+    <li>
+        <h1>Hot Berry Cupcake</h1>
+        <p>You must remember your auntie Judith's garden, and the wonderful berries she was always picking up for dessert? Well, your inner child's heart is going to have to meet the enjoyable roughness of adulthood: when strawberry, cranberry and rapsberry meet tabasco, it's the powerful taste mix that wins the game.</p>
+    </li>
+    <li>
+        <h1>Soft Lemon Cupcake</h1>
+        <p>Nobody blames lemon for its bitterness. And there are times when, more than ever, nobody should! How could bitterness be to blame, while it is so well enclosed in a sweetening-chocolatey setting? And since we don't doubt you are the fine type, you get to have a choice between a softer version (topped with the sweetest bit of white chocolate you could find), or a tougher version (topped with a provocative bitter lemon jelly). Sweet white chocolate + lemon bitterness = the magic power of an unexpected encounter.</p>
+    </li>
+    <li>
+        <h1>Speculoos Cupcake</h1>
+        <p>It was yet another travel that <em>Les Bonnes Choses</em> had to offer you. Take a sweet trip to the wonderful Brussels, and as you enjoy a typically Belgian coffee with waffles, let yourself bite into the purest expression of the typical Speculoos taste, concentrated into a single cupcake.</p>
+    </li>
+    <li>
+        <h1>Triple Chocolate Cupcake</h1>
+        <p>Do you know what's better than double-chocolate? Triple-chocolate! The chocolate cake at the bottom supports the chocolate cream, which supports tiny, soft minced chocolate ; and together, they support an overwhelming taste of chocolate in your mouth.</p>
+    </li>
+</ul>
+</body>
+</html>

--- a/test/fixtures/preview/expected/index.html
+++ b/test/fixtures/preview/expected/index.html
@@ -22,5 +22,52 @@
         <p>Do you know what's better than double-chocolate? Triple-chocolate! The chocolate cake at the bottom supports the chocolate cream, which supports tiny, soft minced chocolate ; and together, they support an overwhelming taste of chocolate in your mouth.</p>
     </li>
 </ul>
+<ul>
+    <li>
+        <h1>Art Director</h1>
+        <a href="/store/UlfoxUnM0wkXYXbb/paris-saint-lazare">/store/UlfoxUnM0wkXYXbb/paris-saint-lazare</a>
+        <p>Brand visual identity must be vital to you, and you must have a thorough experience with working for/with great visual brands. We will ask you to present your previous work, and explain your choices, so be prepared. Previous work with luxury brands is a plus.</p>
+    </li>
+    <li>
+        <h1>Store Intern</h1>
+        <a href="/store/UlfoxUnM0wkXYXbc/new-york-fifth-avenue">/store/UlfoxUnM0wkXYXbc/new-york-fifth-avenue</a>
+        <p>We expect only one skill from our store interns: an infinite thirst to learn about fine pastry. You might not know much about how to prepare them. You might not know much about how to sell them, and advise about them. You might not know how a pastry shop runs. We've got all of that covered for you.</p><p>Be sure to have the proper motivation, and your future with us will shine bright: we've been offering jobs to all of our interns at the end of their internship.</p>
+    </li>
+    <li>
+        <h1>Content Director</h1>
+        <a href="/store/UlfoxUnM0wkXYXbb/paris-saint-lazare">/store/UlfoxUnM0wkXYXbb/paris-saint-lazare</a>
+        <p>As a company whose marketing is very content-centric, we expect our Content Director to have a tremendous experience, both in content strategy, and in content writing. We expect our applicants to show off some of the content strategies they set up themselves, explaining their choices, and to provide amazing contents they personally wrote.</p><p>Our contents get flexibly powerfully shared on various supports: our site, our in-store printed magazine, our mobile apps, our mailings ... Our Content Director must have experience with all of those, and with using modern adaptive content managers such as <a href="http://prismic.io">prismic.io</a>.</p>
+    </li>
+    <li>
+        <h1>Ganache Specialist</h1>
+        <a href="/store/UlfoxUnM0wkXYXbb/paris-saint-lazare">/store/UlfoxUnM0wkXYXbb/paris-saint-lazare</a>
+        <p>It takes a solid whipping and crystalizing experience to build perfect ganaches. Ganaches can be built from the top down (building a hard material, and softening it), or from the bottom up (coming from a near-liquid state, and making it thicker), and only you know just the way to go to get the perfect output.</p><p>Experienced and highly motivated in fine pastry, you are able to come up with better techniques and formulas to make your art always better.</p>
+    </li>
+    <li>
+        <h1>Community Manager</h1>
+        <a href="/store/UlfoxUnM0wkXYXbb/paris-saint-lazare">/store/UlfoxUnM0wkXYXbb/paris-saint-lazare</a>
+        <p>Mastering the art of direct communication is an experimented skill by itself; and mastering the ability to adapt to the ever-changing modern communication environment is another one. As our community manager, you will need to be proficient with both.</p><p>You will also need to have experience in both aspects, and it's much better if you have worked for/with luxury brands before (not necessarily food-related).</p>
+    </li>
+    <li>
+        <h1>Oven Instrumentist</h1>
+        <a href="/store/UlfoxUnM0wkXYXbc/new-york-fifth-avenue">/store/UlfoxUnM0wkXYXbc/new-york-fifth-avenue</a>
+        <p>A musical instrument does nothing by itself; a musical instrumentalist is but a person. But together, they play an art that is bigger than the sum of the man and the instrument, and generate powerful emotions. It takes a lot of technique; but it takes a lot more than technique. We only ask you one thing: that you do have that technique, and that extra thing.</p>
+    </li>
+    <li>
+        <h1>Pastry Dresser</h1>
+        <a href="/store/UlfoxUnM0wkXYXbU/tokyo-roppongi-hills">/store/UlfoxUnM0wkXYXbU/tokyo-roppongi-hills</a>
+        <p>If you are the kind of person who gets intense, insane, almost neurotic about perfection and details, you are exactly the type we're looking for; but be aware that this job will not make your condition better! With an art background and a perfect mastery of the finest paintbrushes, you can modify every bit of an object to make it shine even brighter.</p>
+    </li>
+    <li>
+        <h1>Store Assistant Manager</h1>
+        <a href="/store/UlfoxUnM0wkXYXbP/paris-champ-elysees">/store/UlfoxUnM0wkXYXbP/paris-champ-elysees</a>
+        <p>To be straightforward: as a Store Assistant Manager, your skills will be as strong as the Store Manager, meaning you can manage your teams, balance the books, give any kind of advice to your customers, ... simply run the store! You need to have extensive experience with pastry (or at least, fine cuisine), and to be customer-service-driven.</p><p>The Store Manager is usually a more seasoned <em>Les Bonnes Choses</em> leader, who already had the time to adapt his leadership style to the <em>Les Bonnes Choses</em> approach.</p>
+    </li>
+    <li>
+        <h1>Fruit Expert</h1>
+        <a href="/store/UlfoxUnM0wkXYXbb/paris-saint-lazare">/store/UlfoxUnM0wkXYXbb/paris-saint-lazare</a>
+        <p>Here at Les Bonnes Choses, we acknowledge that it's a talent to know how to turn fresh material by nature, such as fruit, into something that plays well with the other pastry ingredients. Fruit are natural and temperamental, so you need to know exactly how to tame them and convice them to behave as per your will.</p>
+    </li>
+</ul>
 </body>
 </html>

--- a/test/fixtures/preview/src/index.html
+++ b/test/fixtures/preview/src/index.html
@@ -1,0 +1,7 @@
+---
+template: index.hbt
+prismic:
+  cupcake:
+    query: '[[:d = at(document.tags, ["Cupcake"])] [:d = any(document.type, ["product"])]]'
+    orderings: '[my.product.name]'
+---

--- a/test/fixtures/preview/src/index.html
+++ b/test/fixtures/preview/src/index.html
@@ -4,4 +4,6 @@ prismic:
   cupcake:
     query: '[[:d = at(document.tags, ["Cupcake"])] [:d = any(document.type, ["product"])]]'
     orderings: '[my.product.name]'
+  jobOffers:
+    query: '[[:d = any(document.type, ["job-offer"])]]'
 ---

--- a/test/fixtures/preview/templates/index.hbt
+++ b/test/fixtures/preview/templates/index.hbt
@@ -8,5 +8,14 @@
     </li>
 {{/each}}
 </ul>
+<ul>
+{{#each prismic.jobOffers.results}}
+    <li>
+        {{{data.name.html}}}
+        {{{data.location.html}}}
+        {{{data.profile.html}}}
+    </li>
+{{/each}}
+</ul>
 </body>
 </html>

--- a/test/fixtures/preview/templates/index.hbt
+++ b/test/fixtures/preview/templates/index.hbt
@@ -1,0 +1,12 @@
+<html>
+<body>
+<ul>
+{{#each prismic.cupcake.results}}
+    <li>
+        {{{data.name.html}}}
+        {{{data.description.html}}}
+    </li>
+{{/each}}
+</ul>
+</body>
+</html>

--- a/test/index.js
+++ b/test/index.js
@@ -174,6 +174,40 @@ describe('metalsmith-prismic', function(){
                 done();
             });
     });
+
+    it('should render release ref', function(done){
+        Metalsmith('test/fixtures/preview')
+            .use(prismic({
+                "url": "http://lesbonneschoses.prismic.io/api",
+                "release": "UlfoxUnM08QWYXdk"  // St-Patrick specials
+            }))
+
+            // .use (log())
+
+            // use Handlebars templating engine to insert content
+            .use(templates({
+                "engine": "handlebars"
+            }))
+
+            .build(function(err){
+                if (err) return done(err);
+                equal('test/fixtures/preview/expected', 'test/fixtures/preview/build');
+                done();
+            });
+    });
+
+    it('should fail gracefully on nonexistent release', function(done){
+        Metalsmith('test/fixtures/preview')
+            .use(prismic({
+                "url": "http://lesbonneschoses.prismic.io/api",
+                "release": "invalid"
+            }))
+
+            .build(function(err){
+                assert.throws(assert.ifError.bind(null, err));
+                done();
+            });
+    });
 });
 
 


### PR DESCRIPTION
Enables passing raw references in the `release` configuration parameter. This allows the user to build  preview rendering of the site using the Prismic.io dashboard preview button.

Suggested solution for #24 