### PR TITLE
Add support for complex fragments

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -84,6 +84,7 @@ function plugin(config) {
                     file.prismic[queryKey].results = [];
                     var queryString = file.prismic[queryKey].query;
                     var orderings = file.prismic[queryKey].orderings;
+                    var fetchLinks = file.prismic[queryKey].fetchLinks;
                     var pageSize = file.prismic[queryKey].pageSize;
                     var allPages = file.prismic[queryKey].allPages;
                     var formName = file.prismic[queryKey].formName;
@@ -104,6 +105,7 @@ function plugin(config) {
                                            "pageSize": pageSize,
                                            "allPages": allPages,
                                            "orderings": orderings,
+                                           "fetchLinks": fetchLinks,
                                            "formName": formName};
                 }
 
@@ -121,6 +123,7 @@ function plugin(config) {
                             .pageSize(queryKeys[currentQueryKey].pageSize)
                             .page(page)
                             .orderings(queryKeys[currentQueryKey].orderings)
+                            .fetchLinks(queryKeys[currentQueryKey].fetchLinks)
                             .ref(ctx.ref).submit(prismicCallback);
                     }
 
@@ -171,10 +174,30 @@ function plugin(config) {
                             var fragment = content.results[i].fragments[fragmentFullName];
 
                             function processSingleFragment(fragment) {
-                              return {
+                              var fragmentObject = {
                                 json: fragment,
                                 html: fragment.asHtml(ctx.linkResolver)
                               };
+
+                              // Add child fragments from links
+                              if (fragment instanceof Prismic.Fragments.DocumentLink && queryMetadata.fetchLinks && fragment.document.data) {
+                                fragmentObject.children = _.mapObject(fragment.document.data[fragment.type], function(field) {
+                                  // Structured text is not fetched nicely by prismic
+                                  if (field.type) {
+                                    fragment = Prismic.Fragments.initField(field);
+                                    return {
+                                      json: fragment,
+                                      html: fragment.asHtml(ctx.linkResolver)
+                                    }
+                                  } else {
+                                    return {
+                                      json: field
+                                    }
+                                  }
+                                });
+                              }
+
+                              return fragmentObject;
                             }
 
                             if (queryMetadata.arrayFragments && Array.isArray(fragment)) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -171,16 +171,10 @@ function plugin(config) {
 
                             // strip the document type from the fragment name
                             var fragmentName = fragmentFullName.substr(fragmentFullName.lastIndexOf('.') + 1);
-                            var fragment = content.results[i].fragments[fragmentFullName];
 
-                            if (queryMetadata.arrayFragments && Array.isArray(fragment)) {
-                              var fragmentArray = content.results[i].getAll(fragmentFullName);
-                              result.data[fragmentName] = fragmentArray.map(function(subfragment) {
-                                return processSingleFragment(subfragment, ctx);
-                              });
-                            } else {
-                              result.data[fragmentName] = processSingleFragment(content.results[i].get(fragmentFullName), ctx);
-                            }
+                            // process fragments recursively
+                            var fragment = content.results[i].fragments[fragmentFullName];
+                            result.data[fragmentName] = processSingleFragment(fragment, ctx, queryMetadata);
                         }
                     }
                     queryMetadata.results.push(result);
@@ -189,27 +183,62 @@ function plugin(config) {
         }
 
         // process a single fragment, and return the fragment object with json and html data
-        function processSingleFragment(fragment, ctx) {
+        function processSingleFragment(fragment, ctx, queryMetadata) {
+          // return array fragments (link[0], link[1], ... named fragments) as arrays if arrayFragments are enabled
+          if (Array.isArray(fragment)) {
+            if (queryMetadata.arrayFragments) {
+              return fragment.map(function(subFragment) {
+                return processSingleFragment(subFragment, ctx, queryMetadata);
+              });
+            } else {
+              // only return first element of array
+              if (fragment.length) {
+                return processSingleFragment(fragment[0], ctx, queryMetadata);
+              } else {
+                // only return one element of empty array, lets say that is null
+                return null;
+              }
+            }
+          }
+
+          // initialize Prismic fragment javascript wrapper, unless already initialized
+          if (!fragment.asHtml) {
+            fragment = Prismic.Fragments.initField(fragment);
+          }
           var fragmentObject = {
             json: fragment,
             html: fragment.asHtml(ctx.linkResolver)
           };
 
-          // Add child fragments from links
+          // Add child fragments
           if (fragment instanceof Prismic.Fragments.DocumentLink && fragment.document.data) {
-            fragmentObject.children = _.mapObject(fragment.document.data[fragment.type], function(field) {
-              // Structured text is not fetched nicely by prismic
-              if (field.type) {
-                fragment = Prismic.Fragments.initField(field);
-                return {
-                  json: fragment,
-                  html: fragment.asHtml(ctx.linkResolver)
-                }
+            // from document links
+            fragmentObject.children = _.mapObject(fragment.document.data[fragment.type], function(subFragment) {
+              if (subFragment.type) {
+                return processSingleFragment(subFragment, ctx, queryMetadata);
               } else {
+                // some document link subfragments aren't proper fragments
+                // for example StructuredText isn't supported
+                // we can't really do anything else than return the raw data
                 return {
-                  json: field
-                }
+                  json: subFragment
+                };
               }
+            });
+          } else if (fragment instanceof Prismic.Fragments.Group) {
+            // from groups
+            fragmentObject.children = _.map(fragment.toArray(), function(group) {
+              return _.mapObject(group.fragments, function(subFragment) {
+                return processSingleFragment(subFragment, ctx, queryMetadata);
+              });
+            });
+          } else if (fragment instanceof Prismic.Fragments.SliceZone) {
+            // TODO
+            fragmentObject.children = _.map(fragment.value, function(sliceFragment) {
+              var subFragmentObject = processSingleFragment(sliceFragment.value, ctx, queryMetadata);
+              subFragmentObject.sliceType = sliceFragment.sliceType;
+              subFragmentObject.sliceLabel = sliceFragment.label;
+              return subFragmentObject;
             });
           }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -155,6 +155,7 @@ function plugin(config) {
         // processes the retrieved content and adds it to the metadata
         function processRetrievedContent(content, filePrismicMetadata, queryKey, ctx) {
             if (content.results != null && content.results.length > 0) {
+                var queryMetadata = filePrismicMetadata[queryKey];
                 for (var i = 0; i < content.results.length; i++) {
 
                     // add the complete result except for the data fragments
@@ -167,12 +168,24 @@ function plugin(config) {
 
                             // strip the document type from the fragment name
                             var fragmentName = fragmentFullName.substr(fragmentFullName.lastIndexOf('.') + 1);
-                            result.data[fragmentName] = {};
-                            result.data[fragmentName].json = content.results[i].get(fragmentFullName);
-                            result.data[fragmentName].html = content.results[i].get(fragmentFullName).asHtml(ctx.linkResolver);
+                            var fragment = content.results[i].fragments[fragmentFullName];
+
+                            function processSingleFragment(fragment) {
+                              return {
+                                json: fragment,
+                                html: fragment.asHtml(ctx.linkResolver)
+                              };
+                            }
+
+                            if (queryMetadata.arrayFragments && Array.isArray(fragment)) {
+                              var fragmentArray = content.results[i].getAll(fragmentFullName);
+                              result.data[fragmentName] = fragmentArray.map(processSingleFragment);
+                            } else {
+                              result.data[fragmentName] = processSingleFragment(content.results[i].get(fragmentFullName));
+                            }
                         }
                     }
-                    filePrismicMetadata[queryKey].results.push(result);
+                    queryMetadata.results.push(result);
                 }
             }
         }

--- a/lib/index.js
+++ b/lib/index.js
@@ -173,44 +173,47 @@ function plugin(config) {
                             var fragmentName = fragmentFullName.substr(fragmentFullName.lastIndexOf('.') + 1);
                             var fragment = content.results[i].fragments[fragmentFullName];
 
-                            function processSingleFragment(fragment) {
-                              var fragmentObject = {
-                                json: fragment,
-                                html: fragment.asHtml(ctx.linkResolver)
-                              };
-
-                              // Add child fragments from links
-                              if (fragment instanceof Prismic.Fragments.DocumentLink && queryMetadata.fetchLinks && fragment.document.data) {
-                                fragmentObject.children = _.mapObject(fragment.document.data[fragment.type], function(field) {
-                                  // Structured text is not fetched nicely by prismic
-                                  if (field.type) {
-                                    fragment = Prismic.Fragments.initField(field);
-                                    return {
-                                      json: fragment,
-                                      html: fragment.asHtml(ctx.linkResolver)
-                                    }
-                                  } else {
-                                    return {
-                                      json: field
-                                    }
-                                  }
-                                });
-                              }
-
-                              return fragmentObject;
-                            }
-
                             if (queryMetadata.arrayFragments && Array.isArray(fragment)) {
                               var fragmentArray = content.results[i].getAll(fragmentFullName);
-                              result.data[fragmentName] = fragmentArray.map(processSingleFragment);
+                              result.data[fragmentName] = fragmentArray.map(function(subfragment) {
+                                return processSingleFragment(subfragment, ctx);
+                              });
                             } else {
-                              result.data[fragmentName] = processSingleFragment(content.results[i].get(fragmentFullName));
+                              result.data[fragmentName] = processSingleFragment(content.results[i].get(fragmentFullName), ctx);
                             }
                         }
                     }
                     queryMetadata.results.push(result);
                 }
             }
+        }
+
+        // process a single fragment, and return the fragment object with json and html data
+        function processSingleFragment(fragment, ctx) {
+          var fragmentObject = {
+            json: fragment,
+            html: fragment.asHtml(ctx.linkResolver)
+          };
+
+          // Add child fragments from links
+          if (fragment instanceof Prismic.Fragments.DocumentLink && fragment.document.data) {
+            fragmentObject.children = _.mapObject(fragment.document.data[fragment.type], function(field) {
+              // Structured text is not fetched nicely by prismic
+              if (field.type) {
+                fragment = Prismic.Fragments.initField(field);
+                return {
+                  json: fragment,
+                  html: fragment.asHtml(ctx.linkResolver)
+                }
+              } else {
+                return {
+                  json: field
+                }
+              }
+            });
+          }
+
+          return fragmentObject;
         }
 
         // if any of the queries are designated the collection query, then generate a file for each of the results

--- a/test/fixtures/fetchLinks/expected/index.html
+++ b/test/fixtures/fetchLinks/expected/index.html
@@ -1,0 +1,135 @@
+<html>
+<body>
+<ul>
+    <li>
+        <h1>Art Director</h1>
+        <ul>
+            <li>
+                <span>Paris Saint-Lazare</span>
+                <span>56 rue Saint-Lazare</span>
+            </li>
+        </ul>
+    </li>
+    <li>
+        <h1>Store Intern</h1>
+        <ul>
+            <li>
+                <span>New York Fifth Avenue</span>
+                <span>767 5th Avenue</span>
+            </li>
+            <li>
+                <span>Tokyo Roppongi Hills</span>
+                <span>2-29-1 Dougenzaka</span>
+            </li>
+            <li>
+                <span>London Covent Garden</span>
+                <span>1, The Market</span>
+            </li>
+            <li>
+                <span>Paris Saint-Lazare</span>
+                <span>56 rue Saint-Lazare</span>
+            </li>
+            <li>
+                <span>Paris Champ-Elysées</span>
+                <span>101 avenue des Champs-Élysées</span>
+            </li>
+        </ul>
+    </li>
+    <li>
+        <h1>Content Director</h1>
+        <ul>
+            <li>
+                <span>Paris Saint-Lazare</span>
+                <span>56 rue Saint-Lazare</span>
+            </li>
+        </ul>
+    </li>
+    <li>
+        <h1>Ganache Specialist</h1>
+        <ul>
+            <li>
+                <span>Paris Saint-Lazare</span>
+                <span>56 rue Saint-Lazare</span>
+            </li>
+            <li>
+                <span>Tokyo Roppongi Hills</span>
+                <span>2-29-1 Dougenzaka</span>
+            </li>
+            <li>
+                <span>London Covent Garden</span>
+                <span>1, The Market</span>
+            </li>
+        </ul>
+    </li>
+    <li>
+        <h1>Community Manager</h1>
+        <ul>
+            <li>
+                <span>Paris Saint-Lazare</span>
+                <span>56 rue Saint-Lazare</span>
+            </li>
+            <li>
+                <span>Tokyo Roppongi Hills</span>
+                <span>2-29-1 Dougenzaka</span>
+            </li>
+        </ul>
+    </li>
+    <li>
+        <h1>Oven Instrumentist</h1>
+        <ul>
+            <li>
+                <span>New York Fifth Avenue</span>
+                <span>767 5th Avenue</span>
+            </li>
+            <li>
+                <span>Tokyo Roppongi Hills</span>
+                <span>2-29-1 Dougenzaka</span>
+            </li>
+            <li>
+                <span>Paris Champ-Elysées</span>
+                <span>101 avenue des Champs-Élysées</span>
+            </li>
+            <li>
+                <span>London Covent Garden</span>
+                <span>1, The Market</span>
+            </li>
+        </ul>
+    </li>
+    <li>
+        <h1>Pastry Dresser</h1>
+        <ul>
+            <li>
+                <span>Tokyo Roppongi Hills</span>
+                <span>2-29-1 Dougenzaka</span>
+            </li>
+        </ul>
+    </li>
+    <li>
+        <h1>Store Assistant Manager</h1>
+        <ul>
+            <li>
+                <span>Paris Champ-Elysées</span>
+                <span>101 avenue des Champs-Élysées</span>
+            </li>
+            <li>
+                <span></span>
+                
+            </li>
+        </ul>
+    </li>
+    <li>
+        <h1>Fruit Expert</h1>
+        <ul>
+            <li>
+                <span>Paris Saint-Lazare</span>
+                <span>56 rue Saint-Lazare</span>
+            </li>
+            <li>
+                <span>London Covent Garden</span>
+                <span>1, The Market</span>
+            </li>
+        </ul>
+    </li>
+</ul>
+</body>
+</html>

--- a/test/fixtures/fetchLinks/src/index.html
+++ b/test/fixtures/fetchLinks/src/index.html
@@ -1,0 +1,8 @@
+---
+template: index.hbt
+prismic:
+  jobOffers:
+    query: '[[:d = any(document.type, ["job-offer"])]]'
+    arrayFragments: true
+    fetchLinks: 'store.name,store.address,product.name'
+---

--- a/test/fixtures/fetchLinks/templates/index.hbt
+++ b/test/fixtures/fetchLinks/templates/index.hbt
@@ -1,0 +1,19 @@
+<html>
+<body>
+<ul>
+  {{#each prismic.jobOffers.results}}
+    <li>
+        {{{data.name.html}}}
+        <ul>
+          {{#each data.location}}
+            <li>
+                <span>{{children.name.json.0.text}}</span>
+                {{{children.address.html}}}
+            </li>
+          {{/each}}
+        </ul>
+    </li>
+  {{/each}}
+</ul>
+</body>
+</html>

--- a/test/fixtures/fragmentList/expected/index.html
+++ b/test/fixtures/fragmentList/expected/index.html
@@ -1,0 +1,56 @@
+<html>
+<body>
+<ul>
+    <li>
+        <h1>Paris Saint-Lazare</h1>
+        <ul>
+          <li><span>2pm - 10pm</span></li>
+          <li><span>2pm - 10pm</span></li>
+          <li><span>2pm - 10pm</span></li>
+          <li><span>2pm - 10pm</span></li>
+          <li><span>2pm - 10pm</span></li>
+        </ul>
+    </li>
+    <li>
+        <h1>Tokyo Roppongi Hills</h1>
+        <ul>
+          <li><span>9am - 10pm</span></li>
+          <li><span>9am - 10pm</span></li>
+          <li><span>9am - 10pm</span></li>
+          <li><span>9am - 10pm</span></li>
+          <li><span>9am - 10pm</span></li>
+        </ul>
+    </li>
+    <li>
+        <h1>London Covent Garden</h1>
+        <ul>
+          <li><span>9am - 8pm</span></li>
+          <li><span>9am - 8pm</span></li>
+          <li><span>9am - 8pm</span></li>
+          <li><span>9am - 8pm</span></li>
+          <li><span>9am - 8pm</span></li>
+        </ul>
+    </li>
+    <li>
+        <h1>Paris Champ-Elysées</h1>
+        <ul>
+          <li><span>9am - 2pm</span><span>3pm - 7pm</span></li>
+          <li><span>9am - 2pm</span><span>3pm - 7pm</span></li>
+          <li><span>9am - 2pm</span><span>3pm - 7pm</span></li>
+          <li><span>9am - 2pm</span><span>3pm - 7pm</span></li>
+          <li><span>9am - 2pm</span><span>3pm - 7pm</span></li>
+        </ul>
+    </li>
+    <li>
+        <h1>New York Fifth Avenue</h1>
+        <ul>
+          <li><span>9am - 10pm</span></li>
+          <li><span>9am - 10pm</span></li>
+          <li><span>9am - 10pm</span></li>
+          <li><span>9am - 10pm</span></li>
+          <li><span>9am - 10pm</span></li>
+        </ul>
+    </li>
+</ul>
+</body>
+</html>

--- a/test/fixtures/fragmentList/src/index.html
+++ b/test/fixtures/fragmentList/src/index.html
@@ -1,0 +1,7 @@
+---
+template: index.hbt
+prismic:
+  store:
+    query: '[[:d = any(document.type, ["store"])]]'
+    arrayFragments: true
+---

--- a/test/fixtures/fragmentList/templates/index.hbt
+++ b/test/fixtures/fragmentList/templates/index.hbt
@@ -1,0 +1,18 @@
+<html>
+<body>
+<ul>
+{{#each prismic.store.results}}
+    <li>
+        {{{data.name.html}}}
+        <ul>
+          <li>{{{data.monday.0.html}}}{{{data.monday.1.html}}}</li>
+          <li>{{{data.tuesday.0.html}}}{{{data.tuesday.1.html}}}</li>
+          <li>{{{data.wednesday.0.html}}}{{{data.wednesday.1.html}}}</li>
+          <li>{{{data.thursday.0.html}}}{{{data.thursday.1.html}}}</li>
+          <li>{{{data.friday.0.html}}}{{{data.friday.1.html}}}</li>
+        </ul>
+    </li>
+{{/each}}
+</ul>
+</body>
+</html>

--- a/test/fixtures/groups/expected/index.html
+++ b/test/fixtures/groups/expected/index.html
@@ -1,0 +1,50 @@
+<html>
+<body>
+<ul>
+    <li>
+        <span>John Doe</span>
+        <dl>
+            <dt>street</dt>
+            <dd><span>Hight Street</span></dd>
+            <dt>zip</dt>
+            <dd><span>12345</span></dd>
+            <dt>city</dt>
+            <dd><span>Anytown</span></dd>
+        </dl>
+    </li>
+    <li>
+        <span>Jane Doe</span>
+        <dl>
+            <dt>street</dt>
+            <dd><span>Main Street</span></dd>
+            <dt>zip</dt>
+            <dd><span>67890</span></dd>
+            <dt>city</dt>
+            <dd><span>Sometown</span></dd>
+        </dl>
+    </li>
+</ul>
+<ul>
+    <li>
+        <ul>
+            <li>
+                <img src="https://prismic-io.s3.amazonaws.com/api-test/8cb00fd1a4e46f88f76c6b1ae8b0a910c6006e59_apple-pie.png" width="500" height="500" alt="Apple pie">
+                <p><em>Apple</em> pie</p>
+            </li>
+            <li>
+                <img src="https://prismic-io.s3.amazonaws.com/api-test/804e464860491df10a969e40e3a1404a4f261847_kiwi-pie.png" width="500" height="500" alt="">
+                <p><em>Kiwi</em> pie</p>
+            </li>
+            <li>
+                <img src="https://prismic-io.s3.amazonaws.com/api-test/2f4ef8cba993e90635c52dcc4975276a542e45a1_strawberry-pie.png" width="500" height="500" alt="">
+                <p><em>Strawberry</em> pie</p>
+            </li>
+            <li>
+                <img src="https://prismic-io.s3.amazonaws.com/api-test/cdc63e583c1a39424b8f16b9bc583ee7ab5de8c4_cherry-pie.png" width="500" height="500" alt="">
+                <p><em>Cherry</em> pie</p>
+            </li>
+        </ul>
+    </li>
+</ul>
+</body>
+</html>

--- a/test/fixtures/groups/src/index.html
+++ b/test/fixtures/groups/src/index.html
@@ -1,0 +1,8 @@
+---
+template: index.hbt
+prismic:
+  group-single:
+    query: '[[:d = any(document.type, ["group-single"])]]'
+  group-repeat:
+    query: '[[:d = any(document.type, ["group-repeat"])]]'
+---

--- a/test/fixtures/groups/templates/index.hbt
+++ b/test/fixtures/groups/templates/index.hbt
@@ -1,0 +1,31 @@
+<html>
+<body>
+<ul>
+{{#each prismic.group-single.results}}
+    <li>
+        {{{data.name.html}}}
+        <dl>
+        {{#each data.address.children.[0]}}
+            <dt>{{@key}}</dt>
+            <dd>{{{html}}}</dd>
+        {{/each}}
+        </dl>
+    </li>
+{{/each}}
+</ul>
+<ul>
+{{#each prismic.group-repeat.results}}
+    <li>
+        <ul>
+        {{#each data.gallery.children}}
+            <li>
+                {{{image.html}}}
+                {{{caption.html}}}
+            </li>
+        {{/each}}
+        </ul>
+    </li>
+{{/each}}
+</ul>
+</body>
+</html>

--- a/test/fixtures/slices/expected/index.html
+++ b/test/fixtures/slices/expected/index.html
@@ -1,0 +1,44 @@
+<html>
+<body>
+<ul>
+    <li>
+        <div class="image">
+            <img src="https://prismic-io.s3.amazonaws.com/api-test/0d5f11ae169105248144293669bd526369ca3a23_jean-michel.jpg" width="640" height="960" alt="">
+        </div>
+        <div class="text">
+            <p>Jean-Michel Pastranova, the founder of <em>Les Bonnes Choses</em>, and creator of the whole concept of modern fine pastry, has decided to step down as the CEO and the Director of Workshops of <em>Les Bonnes Choses</em>, to focus on other projects, among which his now best-selling pastry cook books, but also to take on a primary role in a culinary television show to be announced later this year.</p>
+        </div>
+        <div class="quote">
+            <p>I believe I've taken the Les Bonnes Choses concept as far as it can go. Les Bonnes Choses is already an entity that is driven by its people, thanks to a strong internal culture, so I don't feel like they need me as much as they used to. I'm sure they are greater ways to come, to innovate in pastry, and I'm sure Les Bonnes Choses's coming innovation will be even more mind-blowing than if I had stayed longer.</p>
+        </div>
+        <div class="text">
+            <p>He will remain as a senior advisor to the board, and to the workshop artists, as his daughter Selena, who has been working with him for several years, will fulfill the CEO role from now on.</p>
+        </div>
+        <div class="quote">
+            <p>My father was able not only to create a revolutionary concept, but also a company culture that puts everyone in charge of driving the company's innovation and quality. That gives us years, maybe decades of revolutionary ideas to come, and there's still a long, wonderful path to walk in the fine pastry world.</p>
+        </div>
+    </li>
+</ul>
+<ul>
+    <li>
+        <div class="gallery">
+            <div class="image">
+                <img src="https://prismic-io.s3.amazonaws.com/api-test/2829e3badec6a5a8c6c4a4ea045f0c0f4499a7ec_pastry-art-1.jpg" width="900" height="900" alt="">
+                <h3>Preparation</h3>
+            </div>
+            <div class="image">
+                <img src="https://prismic-io.s3.amazonaws.com/api-test/dd75e6a7ad4255d4e72091682f1ea860cc42b737_pastry-art-2.png" width="900" height="420" alt="">
+                <h3>Teamwork</h3>
+            </div>
+            <div class="image">
+                <img src="https://prismic-io.s3.amazonaws.com/api-test/71a71eeba3b79ed242d09308f62887cee8891444_pastry-art-3.jpg" width="900" height="600" alt="">
+                <h3>Satisfied tablet user!</h3>
+            </div>
+        </div>
+        <div class="text">
+            <p>Each year, Les Bonnes Choses organizes a world-famous two-day event called the "Pastry Art Brainstorm", and which is the perfect excuse for every fine pastry artist in the world to exercise their art, and build their skills up. The event is a multiple win-win operation, at many levels: see what the event is, as seen by many point of views.</p><h2>As seen by the top pastry artists worldwide</h2><p>The event always starts with half a day of conference talks, given by the most insightful pastry artists in the world, selected for having made tremendous achievements in pastry that year. The list of invited guest speakers is decided jointly by the Les Bonnes Choses staff and the Fine Pastry Magazine editors.</p><p>This is great for the speakers, who get an occasion to share their work, and have people build up on it with them.</p><h2>As seen by the pastry professionals</h2><p>After half a day of thoughtful conference, the professionals will get to put what they learned to good use, and mingle with the best artists worldwide to make the most daring pastries together. There are no set rules about who does what during this giant innovation workshop, and many crazy ideas get created out of thin air. As a virtually infinite amount of ingredients is provided by the Les Bonnes Choses staff, many unexpected pastries happen on that day, and professionals taste each other's creations, and provide relevant feedback to each other. Most pieces get showcased to the amateur audience as well, who get invited to taste some of the pieces.</p><p>At noon on the second day, teams are expected to subscribe to our Pastry Art Challenge, during which they will make the best possible pastry, judged on many aspects (originality, taste, looks, ...) by a jury of amateurs and professionals. The team members of the three winning pieces share a substantial prize, and their pastries may even join the Les Bonnes Choses catalogue, and be offered in all the Les Bonnes Choses shops worldwide!</p><h2>As seen by the pastry amateurs</h2><p>The conference is limited with a reasonable fee; but the showcase is open to everyone, although visitors are often expected to pay the pastry chefs for the pastries they taste. The educated amateurs spend their day tasting the most daring pieces, giving some appreciated feedback to their chefs, and challenging their own tastebuds. The novice amateurs usually get a once-in-a-lifetime experience, and often mention being blown away by how rich the fine pastry art can be. All in all, every one goes home with a smile on their faces!</p><h2>As seen by the Les Bonnes Choses interns</h2><p>Every year, we recruit a very limited amount of interns, who get aboard a life-defining adventure around fine pastries, discovering Les Bonnes Choses during half a year, with part of this time spent in one of our shops abroad. We always manage to get them on board at a time when we know they will be able to attend a Fine Pastry Brainstorm, because we consider it is a very defining element in the experience of being part of Les Bonnes Choses.</p><p>Not only do we invite them to the event (whatever the country they are stationed in when the event happens), but we give them a front-row seat! They are part of the jury for the Fine Pastry Challenge, they are introduced to every speaker as the next generation of pastry (thus having the occasion to learn even more, directly from them).</p><h2>As seen by fine pastry as a field</h2><p>There wasn't really an international occasion for pastry artists to join and share, before Les Bonnes Choses came up with the first Fine Pastry Brainstorm, in 2006. Fine Pastry Magazine's first edition was out in 2004, and initiated the idea that pastry art needed to be shared better between professionals. But a proper event to meet up in person was missing, and Les Bonnes Choses is proud to be the one to have come up with it first.</p><p>Since then, more local initiatives have been started (notably in Argentina, and Canada), but none comes close to the size of Les Bonnes Choses's international Fine Pastry Brainstorm.</p><h2>As seen by Les Bonnes Choses</h2><p>As the almost only sponsor of every edition of the event, Les Bonnes Choses makes sure enough ingredients are available for everyone, rents the premises, makes sure the speakers are as comfortable as possible, and takes care of the whole organization! But through the operation, Les Bonnes Choses gains much more than any sponsoring can buy: not only does it get to secure Les Bonnes Choses as the world reference in pastry arts, but it also allows them to claim rightfully that they do offer in their shops the best pastries, created by the world top artists indeed.</p>
+        </div>
+    </li>
+</ul>
+</body>
+</html>

--- a/test/fixtures/slices/src/index.html
+++ b/test/fixtures/slices/src/index.html
@@ -1,0 +1,8 @@
+---
+template: index.hbt
+prismic:
+  slices:
+    query: '[[:d = any(document.type, ["slices"])]]'
+  slices-group:
+    query: '[[:d = any(document.type, ["slices-group"])]]'
+---

--- a/test/fixtures/slices/templates/index.hbt
+++ b/test/fixtures/slices/templates/index.hbt
@@ -1,0 +1,34 @@
+<html>
+<body>
+<ul>
+{{#each prismic.slices.results}}
+    <li>
+        {{#each data.body.children}}
+        <div class="{{this.sliceType}}">
+            {{{this.html}}}
+        </div>
+        {{/each}}
+    </li>
+{{/each}}
+</ul>
+<ul>
+{{#each prismic.slices-group.results}}
+    <li>
+        {{#each data.body.children}}
+        <div class="{{this.sliceType}}">
+            {{!-- {{Workaround for missing switch-case in Handlebars}} --}}
+            {{#each this.children}}
+            <div class="image">
+                {{{this.illustration.html}}}
+                {{{this.caption.html}}}
+            </div>
+            {{else}}
+            {{{this.html}}}
+            {{/each}}
+        </div>
+        {{/each}}
+    </li>
+{{/each}}
+</ul>
+</body>
+</html>

--- a/test/index.js
+++ b/test/index.js
@@ -3,6 +3,7 @@ var assert = require('assert');
 var Metalsmith = require('metalsmith');
 var prismic = require('..');
 var templates = require('metalsmith-templates');
+var Handlebars = require('handlebars');
 
 describe('metalsmith-prismic', function(){
     it('should retrieve content from Prismic', function(done){
@@ -25,6 +26,45 @@ describe('metalsmith-prismic', function(){
             });
     });
 
+    it('should handle group fragments', function(done){
+        Metalsmith('test/fixtures/groups')
+            .use(prismic({
+                "url": "http://api-test.prismic.io/api"
+            }))
+
+            //.use (log())
+
+            // use Handlebars templating engine to insert content
+            .use(templates({
+                "engine": "handlebars"
+            }))
+
+            .build(function(err){
+                if (err) return done(err);
+                equal('test/fixtures/groups/expected', 'test/fixtures/groups/build');
+                done();
+            });
+    });
+
+    it('should handle slice fragments', function(done){
+        Metalsmith('test/fixtures/slices')
+            .use(prismic({
+                "url": "http://api-test.prismic.io/api"
+            }))
+
+            //.use (log())
+
+            // use Handlebars templating engine to insert content
+            .use(templates({
+                "engine": "handlebars"
+            }))
+
+            .build(function(err){
+                if (err) return done(err);
+                equal('test/fixtures/slices/expected', 'test/fixtures/slices/build');
+                done();
+            });
+    });
     it('should handle fragment lists', function(done){
         Metalsmith('test/fixtures/fragmentList')
             .use(prismic({

--- a/test/index.js
+++ b/test/index.js
@@ -25,6 +25,26 @@ describe('metalsmith-prismic', function(){
             });
     });
 
+    it('should handle fragment lists', function(done){
+        Metalsmith('test/fixtures/fragmentList')
+            .use(prismic({
+                "url": "http://lesbonneschoses.prismic.io/api"
+            }))
+
+            //.use (log())
+
+            // use Handlebars templating engine to insert content
+            .use(templates({
+                "engine": "handlebars"
+            }))
+
+            .build(function(err){
+                if (err) return done(err);
+                equal('test/fixtures/fragmentList/expected', 'test/fixtures/fragmentList/build');
+                done();
+            });
+    });
+
     it('should generate links with the custom linkResolver', function(done){
         Metalsmith('test/fixtures/linkResolver')
             .use(prismic({

--- a/test/index.js
+++ b/test/index.js
@@ -45,6 +45,26 @@ describe('metalsmith-prismic', function(){
             });
     });
 
+    it('should handle fetch link content', function(done){
+        Metalsmith('test/fixtures/fetchLinks')
+            .use(prismic({
+                "url": "http://lesbonneschoses.prismic.io/api"
+            }))
+
+            //.use (log())
+
+            // use Handlebars templating engine to insert content
+            .use(templates({
+                "engine": "handlebars"
+            }))
+
+            .build(function(err){
+                if (err) return done(err);
+                equal('test/fixtures/fetchLinks/expected', 'test/fixtures/fetchLinks/build');
+                done();
+            });
+    });
+
     it('should generate links with the custom linkResolver', function(done){
         Metalsmith('test/fixtures/linkResolver')
             .use(prismic({


### PR DESCRIPTION
This pull request adds support for two fragment features in Prismic.io:

 1. Fragment arrays
 2. fetchLinks parameter

### Fragment lists

Prismic has an undocumented feature where fragments named like `location[0]`, `location[1]` and so on, will be returned as an array in the request response. Currently metalsmith-prismic will only provide the first value of the array. This is used in "Les Bonnes Choses" for the locations of a [`job-offering`](http://lesbonneschoses.prismic.io/api/documents/search?ref=UlfoxUnM08QWYXdl&q=%5B%5B%3Ad+%3D+any(document.type%2C+%5B%22job-offer%22%5D)%5D%5D#format=json).

This pull request adds a new per-query parameter `arrayFragments` which enables returning the whole array of fragments, instead of only the first one. The query parameter is required to maintain backwards compatibility with existing uses.


### `fetchLinks`

Prismic supports fetching data from nested documents through links using the poorly documented [`fetchLinks`](https://github.com/prismicio/javascript-kit/blob/1.1.7/src/api.js#L525) query parameter.

This pull request also adds support for passing this parameter, and provides `asHtml` processed versions of these nested fields in the `children` property of the fragment.