### PR TITLE
Add support for Prismic bookmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ prismic:
 ###### query
 The required `query` parameter specifies the query to run, following the [Prismic's predicate-based query syntax](https://developers.prismic.io/documentation/api-documentation#predicate-based-queries).
 
+###### bookmark
+The `query` parameter may be replaced by a `bookmark` parameter, which fetches a single document defined by a [Prismic bookmark](https://developers.prismic.io/documentation/repository-administrators-manual#bookmarks).
+
 ###### orderings
 The optional `orderings` parameter specifies how the results should be ordered, following the [Prismic's ordering syntax](https://developers.prismic.io/documentation/api-documentation#orderings).
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -89,6 +89,7 @@ function plugin(config) {
                     debug("processing %s", queryKey);
                     file.prismic[queryKey].results = [];
                     var queryString = file.prismic[queryKey].query;
+                    var bookmark = file.prismic[queryKey].bookmark;
                     var orderings = file.prismic[queryKey].orderings;
                     var fetchLinks = file.prismic[queryKey].fetchLinks;
                     var pageSize = file.prismic[queryKey].pageSize;
@@ -108,6 +109,7 @@ function plugin(config) {
                         }
                     }
                     queryKeys[queryKey] = {"queryString": queryString,
+                                           "bookmark": bookmark,
                                            "pageSize": pageSize,
                                            "allPages": allPages,
                                            "orderings": orderings,
@@ -121,7 +123,21 @@ function plugin(config) {
                     var totalPages;
                     var page = 1;
 
-                    queryNextPage();
+                    if (queryKeys[currentQueryKey].queryString) {
+                        // fetch by query
+                        queryNextPage();
+                    } else if (queryKeys[currentQueryKey].bookmark) {
+                        // fetch by bookmark
+                        var bookmarkID = ctx.api.bookmarks[queryKeys[currentQueryKey].bookmark];
+                        if (bookmarkID) {
+                            ctx.api.getByID(bookmarkID, {}, prismicBookmarkCallback);
+                        } else {
+                            // Missing bookmark, leave data empty
+                            queriedAndProcessedCallback();
+                        }
+                    } else {
+                        throw new TypeError('Must specify either query or bookmark');
+                    }
 
                     function queryNextPage() {
                         ctx.api.form(queryKeys[currentQueryKey].formName)
@@ -130,10 +146,10 @@ function plugin(config) {
                             .page(page)
                             .orderings(queryKeys[currentQueryKey].orderings)
                             .fetchLinks(queryKeys[currentQueryKey].fetchLinks)
-                            .ref(ctx.ref).submit(prismicCallback);
+                            .ref(ctx.ref).submit(prismicQueryCallback);
                     }
 
-                    function prismicCallback(err, d) {
+                    function prismicQueryCallback(err, d) {
                         if (err) {
                             queriedAndProcessedCallback(err);
                         }
@@ -147,6 +163,15 @@ function plugin(config) {
                             } else {
                                 queriedAndProcessedCallback();
                             }
+                        }
+                    }
+
+                    function prismicBookmarkCallback(err, d) {
+                        if (err) {
+                            queriedAndProcessedCallback(err);
+                        } else {
+                            file.prismic[currentQueryKey] = processRetrievedDocument(d, file.prismic, currentQueryKey, ctx);
+                            queriedAndProcessedCallback();
                         }
                     }
 
@@ -168,26 +193,31 @@ function plugin(config) {
             if (content.results != null && content.results.length > 0) {
                 var queryMetadata = filePrismicMetadata[queryKey];
                 for (var i = 0; i < content.results.length; i++) {
-
-                    // add the complete result except for the data fragments
-                    var result = _.omit(content.results[i], 'fragments');
-                    result.data = {};
-
-                    // process the data fragments, invoking helpers to make the data more usable
-                    if (content.results[i].fragments != null && Object.keys(content.results[i].fragments).length  > 0) {
-                        for (var fragmentFullName in content.results[i].fragments) {
-
-                            // strip the document type from the fragment name
-                            var fragmentName = fragmentFullName.substr(fragmentFullName.lastIndexOf('.') + 1);
-
-                            // process fragments recursively
-                            var fragment = content.results[i].fragments[fragmentFullName];
-                            result.data[fragmentName] = processSingleFragment(fragment, ctx, queryMetadata);
-                        }
-                    }
-                    queryMetadata.results.push(result);
+                    var result = processRetrievedDocument(content.results[i], filePrismicMetadata, queryKey, ctx);
+                    filePrismicMetadata[queryKey].results.push(result);
                 }
             }
+        }
+
+        // processes and return single retrieved document
+        function processRetrievedDocument(document, filePrismicMetadata, queryKey, ctx) {
+            // add the complete result except for the data fragments
+            var result = _.omit(document, 'fragments');
+            result.data = {};
+
+            // process the data fragments, invoking helpers to make the data more usable
+            if (document.fragments != null && Object.keys(document.fragments).length  > 0) {
+                for (var fragmentFullName in document.fragments) {
+
+                    // strip the document type from the fragment name
+                    var fragmentName = fragmentFullName.substr(fragmentFullName.lastIndexOf('.') + 1);
+
+                    var fragment = document.fragments[fragmentFullName];
+                    result.data[fragmentName] = processSingleFragment(fragment, ctx, filePrismicMetadata[queryKey]);
+                }
+            }
+
+            return result;
         }
 
         // process a single fragment, and return the fragment object with json and html data

--- a/test/fixtures/bookmarks/expected/index.html
+++ b/test/fixtures/bookmarks/expected/index.html
@@ -1,0 +1,20 @@
+<html>
+<body>
+    <div class="about">
+        <h1>About us</h1>
+        <p>Making great pastry is our passion. Turning them into people's delight is our commitment. Understand our values and learn to know us.</p>
+    </div>
+    <div class="jobs">
+        <h1>Be at the top of the fine pastry scene</h1>
+        <p>Join us, and get involved with creating the finest pastries that can be humanly made, and providing them to our customers.</p>
+    </div>
+    <div class="stores">
+        <h1>Don't be a stranger!</h1>
+        <p>They say it's better to travel with friends; that's why our staff is always friendly when they introduce you to the finest flavor journeys.</p>
+    </div>
+    <div class="missing">
+        
+        
+    </div>
+</body>
+</html>

--- a/test/fixtures/bookmarks/src/index.html
+++ b/test/fixtures/bookmarks/src/index.html
@@ -1,0 +1,12 @@
+---
+template: index.hbt
+prismic:
+  about:
+    bookmark: 'about'
+  jobs:
+    bookmark: 'jobs'
+  stores:
+    bookmark: 'stores'
+  missing:
+    bookmark: 'missing'
+---

--- a/test/fixtures/bookmarks/templates/index.hbt
+++ b/test/fixtures/bookmarks/templates/index.hbt
@@ -1,0 +1,20 @@
+<html>
+<body>
+    <div class="about">
+        {{{ prismic.about.data.title.html }}}
+        {{{ prismic.about.data.short_lede.html }}}
+    </div>
+    <div class="jobs">
+        {{{ prismic.jobs.data.title.html }}}
+        {{{ prismic.jobs.data.short_lede.html }}}
+    </div>
+    <div class="stores">
+        {{{ prismic.stores.data.title.html }}}
+        {{{ prismic.stores.data.short_lede.html }}}
+    </div>
+    <div class="missing">
+        {{{ prismic.missing.data.title.html }}}
+        {{{ prismic.missing.data.short_lede.html }}}
+    </div>
+</body>
+</html>

--- a/test/index.js
+++ b/test/index.js
@@ -105,6 +105,26 @@ describe('metalsmith-prismic', function(){
             });
     });
 
+    it('should retrieve bookmarks from Prismic', function(done){
+        Metalsmith('test/fixtures/bookmarks')
+            .use(prismic({
+                "url": "http://lesbonneschoses.prismic.io/api"
+            }))
+
+            //.use (log())
+
+            // use Handlebars templating engine to insert content
+            .use(templates({
+                "engine": "handlebars"
+            }))
+
+            .build(function(err){
+                if (err) return done(err);
+                equal('test/fixtures/bookmarks/expected', 'test/fixtures/bookmarks/build');
+                done();
+            });
+    });
+
     it('should generate links with the custom linkResolver', function(done){
         Metalsmith('test/fixtures/linkResolver')
             .use(prismic({


### PR DESCRIPTION
Adds support for Prismic bookmarks by allowing users to instead of the current `query` metadata field, use a `bookmark` metadata field. The response is always a single document, so the intermittent `results` list is omitted for bookmark fetches.

Cannot use `getBookmark()` method of the Prismic API, since it seems to be broken. Issue opened at prismicio/javascript-kit#101.
