### PR TITLE
Add url field for links and images

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -250,6 +250,19 @@ function plugin(config) {
             });
           }
 
+          // Add fragment url
+          if (fragment instanceof Prismic.Fragments.DocumentLink) {
+            fragmentObject.url = fragment.url(ctx.linkResolver);
+          } else if (fragment instanceof Prismic.Fragments.WebLink) {
+            fragmentObject.url = fragment.url();
+          } else if (fragment instanceof Prismic.Fragments.FileLink) {
+            fragmentObject.url = fragment.url();
+          } else if (fragment instanceof Prismic.Fragments.ImageLink) {
+            fragmentObject.url = fragment.url();
+          } else if (fragment instanceof Prismic.Fragments.Image) {
+            fragmentObject.url = fragment.url;
+          }
+
           return fragmentObject;
         }
 

--- a/test/fixtures/link-url/expected/index.html
+++ b/test/fixtures/link-url/expected/index.html
@@ -1,0 +1,34 @@
+<html>
+<body>
+<ul>
+    <li style="background-image: url(https://prismic-io.s3.amazonaws.com/lesbonneschoses/79a7a068ceb47892ac8de2480e878962d8b93cc6.png);">
+        <h1>Cool Coconut Macaron</h1>
+        <a href="/product/UlfoxUnM0wkXYXbH/vanilla-macaron">Related</a>
+    </li>
+    <li style="background-image: url(https://prismic-io.s3.amazonaws.com/lesbonneschoses/604400b41b2e275ee766bd69b69b33734043aa38.png);">
+        <h1>Salted Caramel Macaron</h1>
+        <a href="/product/UlfoxUnM0wkXYXbE/dark-chocolate-macaron">Related</a>
+    </li>
+    <li style="background-image: url(https://prismic-io.s3.amazonaws.com/lesbonneschoses/78ef921308fe727a88530a76f6ab6e1123cdd147.png);">
+        <h1>Speculoos Macaron</h1>
+        <a href="/product/UlfoxUnM0wkXYXbT/speculoos-cupcake">Related</a>
+    </li>
+    <li style="background-image: url(https://prismic-io.s3.amazonaws.com/lesbonneschoses/acc69618fab22be90aed95b39b91b62a80595a6b.png);">
+        <h1>Black &amp; White Macaron</h1>
+        <a href="/product/UlfoxUnM0wkXYXbD/speculoos-macaron">Related</a>
+    </li>
+    <li style="background-image: url(https://prismic-io.s3.amazonaws.com/lesbonneschoses/b6d184431d8f2902b97983e6469ffc577da751b3.png);">
+        <h1>Pistachio Macaron</h1>
+        <a href="/product/UlfoxUnM0wkXYXbH/vanilla-macaron">Related</a>
+    </li>
+    <li style="background-image: url(https://prismic-io.s3.amazonaws.com/lesbonneschoses/90954eac02861c4134431e3acb4f27938c5c5ce5.png);">
+        <h1>Dark Chocolate Macaron</h1>
+        <a href="/product/UlfoxUnM0wkXYXbe/woodland-cherry-pie">Related</a>
+    </li>
+    <li style="background-image: url(https://prismic-io.s3.amazonaws.com/lesbonneschoses/fe939eeb67713903f7f68c31efc98e52e1c7655d.png);">
+        <h1>Vanilla Macaron</h1>
+        <a href="/product/UlfoxUnM0wkXYXbE/dark-chocolate-macaron">Related</a>
+    </li>
+</ul>
+</body>
+</html>

--- a/test/fixtures/link-url/src/index.html
+++ b/test/fixtures/link-url/src/index.html
@@ -1,0 +1,6 @@
+---
+template: index.hbt
+prismic:
+  macaron:
+    query: '[[:d = at(document.tags, ["Macaron"])] [:d = any(document.type, ["product"])]]'
+---

--- a/test/fixtures/link-url/templates/index.hbt
+++ b/test/fixtures/link-url/templates/index.hbt
@@ -1,0 +1,12 @@
+<html>
+<body>
+<ul>
+{{#each prismic.macaron.results}}
+    <li style="background-image: url({{{data.image.url}}});">
+        {{{data.name.html}}}
+        <a href="{{data.related.url}}">Related</a>
+    </li>
+{{/each}}
+</ul>
+</body>
+</html>

--- a/test/index.js
+++ b/test/index.js
@@ -105,6 +105,26 @@ describe('metalsmith-prismic', function(){
             });
     });
 
+    it('should provide link fragment urls', function(done){
+        Metalsmith('test/fixtures/link-url')
+            .use(prismic({
+                "url": "http://lesbonneschoses.prismic.io/api"
+            }))
+
+            //.use (log())
+
+            // use Handlebars templating engine to insert content
+            .use(templates({
+                "engine": "handlebars"
+            }))
+
+            .build(function(err){
+                if (err) return done(err);
+                equal('test/fixtures/link-url/expected', 'test/fixtures/link-url/build');
+                done();
+            });
+    });
+
     it('should generate links with the custom linkResolver', function(done){
         Metalsmith('test/fixtures/linkResolver')
             .use(prismic({


### PR DESCRIPTION
Add a url field for fragments with an URL, such as links and images. This is in order to make it easier to create custom links with arbitrary content within the `<a>` tag.
