### PR TITLE
Text output

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ prismic:
     orderings: '[my.hero-slide.seqNum]'
     pageSize: 50
     arrayFragments: true
+    output: html, text
   blog:
     query: '[[:d = at(document.type, "blog")]]'
     allPages: true
@@ -86,6 +87,9 @@ Prismic has an undocumented feature where fragments named like location[0], loca
 
 ###### formName
 By default the query runs against the _everything_ Prismic form. To run against a different form (eg. a collection), provide the `formName` (eg. collection name)
+
+###### output
+By default the plugin will generate the HTML output for each Prismic fragment. Use the `output` parameter to control which outputs to generate from the fragments. Valid outputs are `html` and `text`, multiple options should be comma separated.
 
 This pulls the Prismic response into the file's metadata.
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -214,9 +214,19 @@ function plugin(config) {
             fragment = Prismic.Fragments.initField(fragment);
           }
           var fragmentObject = {
-            json: fragment,
-            html: fragment.asHtml(ctx.linkResolver, ctx.htmlSerializer)
+            json: fragment
           };
+
+          if (!queryMetadata.output || queryMetadata.output.indexOf('html') > -1) {
+            fragmentObject.html = fragment.asHtml(ctx.linkResolver, ctx.htmlSerializer);
+          }
+
+          if (queryMetadata.output && queryMetadata.output.indexOf('text') > -1) {
+            //  https://github.com/prismicio/javascript-kit/issues/104
+            if (!(fragment instanceof Prismic.Fragments.SliceZone) && !(fragment instanceof Prismic.Fragments.SliceZone)) {
+              fragmentObject.text = fragment.asText(ctx.linkResolver);
+            }
+          }
 
           // Add child fragments
           if (fragment instanceof Prismic.Fragments.DocumentLink && fragment.document.data) {

--- a/test/fixtures/textOutput/expected/index.md
+++ b/test/fixtures/textOutput/expected/index.md
@@ -1,0 +1,52 @@
+# Macarons
+
+## Black & White Macaron
+If you feel like antique, experimented tastes are the way to go, then this macaron is perfect for you! A solid touch of dark chocolate, enveloped by a softening touch of vanilla, will take the best of both familiar world, to carry you to a brand new experience! Because you know Les Bonnes Choses always finds out just how to renew your classics for you...
+
+## Cool Coconut Macaron
+If you ever met coconut taste on its bad day, you surely know that coconut, coming from bad-tempered islands, can be rough sometimes. That is why we like to soften it with a touch of caramel taste in its ganache. The result is the perfect encounter between the finest palm fruit and the most tasty of sugarcane's offspring.
+
+## Dark Chocolate Macaron
+There is so much rich, decadent chocolate in this macaron that the chocolatey pleasure is just endless!  As you let the softness and the strength of our preciously selected cocoa waken your senses, you will feel a lot of pleasure and a little bit of guilt, for giving in to your dark (chocolate) side again! There's no mistery why our Dark Chocolate Macaron is our longest-running pastry, in our whole collection, since our creation in 1992.
+
+## Pistachio Macaron
+If you are a nut-cuisine-savvy gourmet, you probably noticed that industrial pistachio flavour tastes very different than actual pistachio.  And yet, pistachio nuts shelter a pure, delicate taste, that needs preserving as much as possible, until it lands in your hands. Therefore, as you bite into our pistachio macaron, you will feel the pistachio nut bits not only delicately set on top of the macaron, but also inside the ganache itself.
+
+## Salted Caramel Macaron
+It's no wonder why our "Salted Caramel French Macaron" has become our best-selling macaron: on top of the authentic Parisian preparation that has been making our macarons so popular and enjoyed by gourmets, you can also feel the waves of Britanny's ocean as you bite into it. Two of the best French local gastronomies meet in your mouth, and suddenly, it's like French Revolution all over again, contained in a single macaron.
+
+## Speculoos Macaron
+Did you know that World War I warriors on the French-Belgian frontier called an unauthorized truce in December 1914, so they could celebrate Christmas together? That's because in every situation, there's much joy to create and receive, from the natural friendship between the French and the Belgian cultures! So when Belgian speculoos meets French macarons, you get to experience the natural chemistry of cultures that are meant to work perfectly together...
+
+## Vanilla Macaron
+Experience the ultimate vanilla experience. Our vanilla Macarons are made with our very own (in-house) pure extract of Madagascar vanilla, and subtly dusted with our own vanilla sugar (which we make from real vanilla beans).
+
+
+# Job Offers
+
+## Art Director
+Brand visual identity must be vital to you, and you must have a thorough experience with working for/with great visual brands. We will ask you to present your previous work, and explain your choices, so be prepared. Previous work with luxury brands is a plus.
+
+## Store Intern
+We expect only one skill from our store interns: an infinite thirst to learn about fine pastry. You might not know much about how to prepare them. You might not know much about how to sell them, and advise about them. You might not know how a pastry shop runs. We've got all of that covered for you. Be sure to have the proper motivation, and your future with us will shine bright: we've been offering jobs to all of our interns at the end of their internship.
+
+## Content Director
+As a company whose marketing is very content-centric, we expect our Content Director to have a tremendous experience, both in content strategy, and in content writing. We expect our applicants to show off some of the content strategies they set up themselves, explaining their choices, and to provide amazing contents they personally wrote. Our contents get flexibly powerfully shared on various supports: our site, our in-store printed magazine, our mobile apps, our mailings ... Our Content Director must have experience with all of those, and with using modern adaptive content managers such as prismic.io.
+
+## Ganache Specialist
+It takes a solid whipping and crystalizing experience to build perfect ganaches. Ganaches can be built from the top down (building a hard material, and softening it), or from the bottom up (coming from a near-liquid state, and making it thicker), and only you know just the way to go to get the perfect output. Experienced and highly motivated in fine pastry, you are able to come up with better techniques and formulas to make your art always better.
+
+## Community Manager
+Mastering the art of direct communication is an experimented skill by itself; and mastering the ability to adapt to the ever-changing modern communication environment is another one. As our community manager, you will need to be proficient with both. You will also need to have experience in both aspects, and it's much better if you have worked for/with luxury brands before (not necessarily food-related).
+
+## Oven Instrumentist
+A musical instrument does nothing by itself; a musical instrumentalist is but a person. But together, they play an art that is bigger than the sum of the man and the instrument, and generate powerful emotions. It takes a lot of technique; but it takes a lot more than technique. We only ask you one thing: that you do have that technique, and that extra thing.
+
+## Pastry Dresser
+If you are the kind of person who gets intense, insane, almost neurotic about perfection and details, you are exactly the type we're looking for; but be aware that this job will not make your condition better! With an art background and a perfect mastery of the finest paintbrushes, you can modify every bit of an object to make it shine even brighter.
+
+## Store Assistant Manager
+To be straightforward: as a Store Assistant Manager, your skills will be as strong as the Store Manager, meaning you can manage your teams, balance the books, give any kind of advice to your customers, ... simply run the store! You need to have extensive experience with pastry (or at least, fine cuisine), and to be customer-service-driven. The Store Manager is usually a more seasoned Les Bonnes Choses leader, who already had the time to adapt his leadership style to the Les Bonnes Choses approach.
+
+## Fruit Expert
+Here at Les Bonnes Choses, we acknowledge that it's a talent to know how to turn fresh material by nature, such as fruit, into something that plays well with the other pastry ingredients. Fruit are natural and temperamental, so you need to know exactly how to tame them and convice them to behave as per your will.

--- a/test/fixtures/textOutput/src/index.md
+++ b/test/fixtures/textOutput/src/index.md
@@ -1,0 +1,11 @@
+---
+template: index.hbt
+prismic:
+  macaron:
+    query: '[[:d = at(document.tags, ["Macaron"])] [:d = any(document.type, ["product"])]]'
+    orderings: '[my.product.name]'
+    output: text
+  jobOffers:
+    query: '[[:d = any(document.type, ["job-offer"])]]'
+    output: text
+---

--- a/test/fixtures/textOutput/templates/index.hbt
+++ b/test/fixtures/textOutput/templates/index.hbt
@@ -1,0 +1,14 @@
+# Macarons
+{{#each prismic.macaron.results}}
+
+## {{{data.name.text}}}
+{{{data.description.text}}}
+{{/each}}
+
+
+# Job Offers
+{{#each prismic.jobOffers.results}}
+
+## {{{data.name.text}}}
+{{{data.profile.text}}}
+{{/each}}

--- a/test/index.js
+++ b/test/index.js
@@ -26,6 +26,26 @@ describe('metalsmith-prismic', function(){
             });
     });
 
+    it('should support text output', function(done){
+        Metalsmith('test/fixtures/textOutput')
+            .use(prismic({
+                "url": "http://lesbonneschoses.prismic.io/api"
+            }))
+
+            //.use (log())
+
+            // use Handlebars templating engine to insert content
+            .use(templates({
+                "engine": "handlebars"
+            }))
+
+            .build(function(err){
+                if (err) return done(err);
+                equal('test/fixtures/textOutput/expected', 'test/fixtures/textOutput/build');
+                done();
+            });
+    });
+
     it('should handle group fragments', function(done){
         Metalsmith('test/fixtures/groups')
             .use(prismic({


### PR DESCRIPTION
Add support for producing text output of Prismic fragments. Utilizes the `asText` methods of the Prismic fragment objects. Output will be produced alongside the `html` property in the metadata.

This is useful for example when generating search indexes of content, or markdown output of the same content.
